### PR TITLE
Removed www.the-blend.net - this site no longer uses Dancer.

### DIFF
--- a/dancefloor.yml
+++ b/dancefloor.yml
@@ -66,12 +66,6 @@ url: "http://www.softwaresolutionservicesinc.com/"
 title: "Software Solution Services"
 description: "A Minnesota-based technology consulting firm"
 ---
-url: "http://www.the-blend.net/"
-title: "The-Blend.net"
-description: |
-    Blends new music, artists and reviews to make music a fun, comfortable and
-    beautiful thing.
----
 url: "http://www.livro-aberto.net/"
 title: "Livro-Aberto"
 description: |


### PR DESCRIPTION
Hi,

The latest version of www.the-blend.net is not using Dancer, so probably best to remove it from the Dancers page.

I built the new version with Mojolicious, partly to try something new, but also because I prefer to use the more perl-ish syntax. But I still think Dancer is great and will be recommending it to people who want an easy-to-use framework.

Thanks!
