### PR TITLE
Add <form> to search the mailing list with google.

### DIFF
--- a/views/about.tt
+++ b/views/about.tt
@@ -27,6 +27,12 @@ href="http://lists.perldancer.org/cgi-bin/listinfo/dancer-users">subscribe to
 the mailing list</a> if you want to contact users and developers of the project. 
 You can also <a href="http://lists.perldancer.org/pipermail/dancer-users/">read
 the list archives</a>.
+
+<form target="_blank" action="http://www.google.com/search" method="get">
+<input type=hidden name="q" value="site:lists.perldancer.org" />
+Search the mailing list: <input type=text name="q" size=20 value=""/>
+<input type="submit" name="foo" value="Search" />
+</form>
 </p>
 
 <p>


### PR DESCRIPTION
Based on Pedro Melo's nice search tip, this tiny <form> in the "about.tt" page allows users to directly search the mailing list:
http://www.backup-manager.org/pipermail/dancer-users/2011-October/001964.html

I added it to the "about.tt" page simply because that's where the mailing list is mentioned.
perhaps it'll be better suited in the "documentation" section ?
