### PR TITLE
Static version of the PerlDancer website (using Wallflower)

### DIFF
--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -33,6 +33,12 @@ get qr{^/(irc|quickstart|documentation|about|contribute|cheatsheet|donate).html$
     forward "/$page"; # autopage
 };
 
+get '/slides/' => sub {
+    my $res = Dancer::Renderer::_autopage_response( Dancer::FileUtils::path( 'slides' ) );
+    $res->header( 'Content-Type' => 'text/html' );
+    $res;
+};
+
 # Add last tweet to template params
 hook before_template_render => sub {
     shift->{last_tweet} = latest_tweet();

--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -15,7 +15,7 @@ get '/' => sub {
     };
 };
 
-get '/donate/thanks' => sub {
+get '/donate/thanks.html' => sub {
     template 'thanks';
 };
 

--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -23,7 +23,7 @@ get '/testimonials.html' => sub {
     template 'testimonials-display', { testimonials => [ _get_testimonials() ] };
 };
 
-get '/dancefloor' => sub {
+get '/dancefloor.html' => sub {
     my $sites = _get_dancefloor_sites();
     template 'dancefloor-display', { sites => _get_dancefloor_sites() };
 };

--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -28,6 +28,11 @@ get '/dancefloor' => sub {
     template 'dancefloor-display', { sites => _get_dancefloor_sites() };
 };
 
+get qr{^/(irc|quickstart|documentation|about|contribute|cheatsheet|donate).html$} => sub {
+    my ($page) = splat;
+    forward "/$page"; # autopage
+};
+
 # Add last tweet to template params
 hook before_template_render => sub {
     shift->{last_tweet} = latest_tweet();

--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -19,7 +19,7 @@ get '/donate/thanks.html' => sub {
     template 'thanks';
 };
 
-get '/testimonials' => sub {
+get '/testimonials.html' => sub {
     template 'testimonials-display', { testimonials => [ _get_testimonials() ] };
 };
 

--- a/public/404.html
+++ b/public/404.html
@@ -43,22 +43,22 @@
 
 		<!-- START NAV LEFT -->
 		<ul id="nav-left" class="clearme listreset">
-			<li><a href="/quickstart">Quick Start</a></li>
+			<li><a href="/quickstart.html">Quick Start</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/documentation">Documentation</a></li>
+			<li><a href="/documentation.html">Documentation</a></li>
 		</ul>
 		<!-- END NAV LEFT -->
 		
 		<!-- START NAV RIGHT -->
 		<ul id="nav-right" class="clearme listreset">
-			<li><a href="/contribute">Contribute</a></li>
+			<li><a href="/contribute.html">Contribute</a></li>
 			<li class="nav-sep"></li>
 
 			<li><a href="/dancefloor">Dancers</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/about">About</a></li>
+			<li><a href="/about.html">About</a></li>
 		</ul>
 		<!-- END NAV RIGHT -->
 			

--- a/public/404.html
+++ b/public/404.html
@@ -55,7 +55,7 @@
 			<li><a href="/contribute.html">Contribute</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/dancefloor">Dancers</a></li>
+			<li><a href="/dancefloor.html">Dancers</a></li>
 			<li class="nav-sep"></li>
 
 			<li><a href="/about.html">About</a></li>

--- a/public/500.html
+++ b/public/500.html
@@ -43,22 +43,22 @@
 
 		<!-- START NAV LEFT -->
 		<ul id="nav-left" class="clearme listreset">
-			<li><a href="/quickstart">Quick Start</a></li>
+			<li><a href="/quickstart.html">Quick Start</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/documentation">Documentation</a></li>
+			<li><a href="/documentation.html">Documentation</a></li>
 		</ul>
 		<!-- END NAV LEFT -->
 		
 		<!-- START NAV RIGHT -->
 		<ul id="nav-right" class="clearme listreset">
-			<li><a href="/contribute">Contribute</a></li>
+			<li><a href="/contribute.html">Contribute</a></li>
 			<li class="nav-sep"></li>
 
 			<li><a href="/dancefloor">Dancers</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/about">About</a></li>
+			<li><a href="/about.html">About</a></li>
 		</ul>
 		<!-- END NAV RIGHT -->
 			

--- a/public/500.html
+++ b/public/500.html
@@ -55,7 +55,7 @@
 			<li><a href="/contribute.html">Contribute</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/dancefloor">Dancers</a></li>
+			<li><a href="/dancefloor.html">Dancers</a></li>
 			<li class="nav-sep"></li>
 
 			<li><a href="/about.html">About</a></li>

--- a/views/about.tt
+++ b/views/about.tt
@@ -37,14 +37,14 @@ Search the mailing list: <input type=text name="q" size=20 value=""/>
 
 <p>
 It's also possible to use GitHub to submit a patch, see the <a
-href="/contribute">contribute</a> page for more details about collaborating in
+href="/contribute.html">contribute</a> page for more details about collaborating in
 Dancer development.
 </p>
 
 <p>
 You can also reach the development team on <code>irc.perl.org</code>, 
 chan <code>#dancer</code>.  If you don't have an IRC client available, you can
-<a href="/irc">connect using Mibbit web IRC</a>.
+<a href="/irc.html">connect using Mibbit web IRC</a>.
 </p>
 
 <script type="text/javascript">

--- a/views/contribute.tt
+++ b/views/contribute.tt
@@ -27,7 +27,7 @@ Ratings</a></li>
 <li><a href="https://github.com/sukria/Dancer">&quot;Watch&quot; the project on
 GitHub</a></li>
 <li>Dancer-related presentations at conferences etc (see the <a
-href="/slides">slides page</a> for inspiration)
+href="/slides/">slides page</a> for inspiration)
 </ul>
 
 <p>

--- a/views/contribute.tt
+++ b/views/contribute.tt
@@ -54,7 +54,7 @@ the <a href="/dancefloor">Dancefloor page</a>!
 
 <p>
 We have a thriving community in <tt>#dancer</tt> on <tt>irc.perl.org</tt>.
-<a href="/irc">Come join us now</a> and get help, offer feedback, help new
+<a href="/irc.html">Come join us now</a> and get help, offer feedback, help new
 users...
 </p>
 
@@ -105,7 +105,7 @@ track and apply, and thus have a much better chance of being applied!)
 <h3>Donate</h3>
 
 <p>
-If you want to support the team, you can also <a href="/donate">donate</a> -
+If you want to support the team, you can also <a href="/donate.html">donate</a> -
 donations will be used to support development efforts, for instance paying for
 travel to conferences etc.
 </p>

--- a/views/contribute.tt
+++ b/views/contribute.tt
@@ -2,7 +2,7 @@
 
 <p>
 Dancer is a modern Perl project - it's already in use in many production
-deployments (see the <a href="/dancefloor">Dancefloor</a> page for some
+deployments (see the <a href="/dancefloor.html">Dancefloor</a> page for some
 examples) but is still being actively developed and improved.
 </p>
 
@@ -45,7 +45,7 @@ commit some ideas to the crew.
 
 <p>
 If you're using Dancer, please feel free to let us know so we can list you on
-the <a href="/dancefloor">Dancefloor page</a>!
+the <a href="/dancefloor.html">Dancefloor page</a>!
 </p>
 
 

--- a/views/documentation.tt
+++ b/views/documentation.tt
@@ -43,6 +43,6 @@ in order to provide working configuration examples.
 
 <p>
 Even though special care is given to documentation, there might be some 
-errors, so feel free to <a href="/about">contact the development team</a> if
+errors, so feel free to <a href="/about.html">contact the development team</a> if
 you find any.
 </p>

--- a/views/download.tt
+++ b/views/download.tt
@@ -24,5 +24,5 @@ Or even <a href="http://github.com/sukria/Dancer/toggle_watch">follow the Dancer
 </p>
 
 <p>
-Find details about bug reports and patch submission <a href="/contribute">there</a>.
+Find details about bug reports and patch submission <a href="/contribute.html">there</a>.
 </p>

--- a/views/includes/doc-list.tt
+++ b/views/includes/doc-list.tt
@@ -1,5 +1,5 @@
 <ul>
-    <li><a href="/cheatsheet">A cheatsheet</a> (PDF or ODS) by Vladimir Lettiev
+    <li><a href="/cheatsheet.html">A cheatsheet</a> (PDF or ODS) by Vladimir Lettiev
     (thecrux)</li>
     <li><a href="http://p3rl.org/Dancer::Introduction">Dancer::Introduction</a>
     - a gentle introduction to Dancer</li>

--- a/views/index.tt
+++ b/views/index.tt
@@ -228,7 +228,7 @@ ajax '/getloadavg' => sub {
 
 <div id="testimonials" style="">
 	
-	<h3><a href="/testimonials">What people say about Dancer</a>...</h3>
+	<h3><a href="/testimonials.html">What people say about Dancer</a>...</h3>
 
 <br clear="both" />
 <!-- adjust height of this div to fit longest quote -->

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -59,7 +59,7 @@
 			<li><a href="/dancefloor" title="Who's using Dancer">Dancers</a></li>
 			<li class="nav-sep"></li>
 
-                        <li><a href="/slides" title="Presentation slides">Slides</a></li>
+                        <li><a href="/slides/" title="Presentation slides">Slides</a></li>
 		</ul>
 		<!-- END NAV RIGHT -->
 			

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -56,7 +56,7 @@
 			<li><a href="/contribute.html" title="Contributing to the project">Contribute</a></li>
 			<li class="nav-sep"></li>
 
-			<li><a href="/dancefloor" title="Who's using Dancer">Dancers</a></li>
+			<li><a href="/dancefloor.html" title="Who's using Dancer">Dancers</a></li>
 			<li class="nav-sep"></li>
 
                         <li><a href="/slides/" title="Presentation slides">Slides</a></li>

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -41,19 +41,19 @@
 
 		<!-- START NAV LEFT -->
 		<ul id="nav-left" class="clearme listreset">
-			<li><a href="/quickstart" title="Get started quickly">Quick Start</a></li>
+			<li><a href="/quickstart.html" title="Get started quickly">Quick Start</a></li>
 			<li class="nav-sep"></li>
-			<li><a href="/documentation" title="Documentation">Docs</a></li>
+			<li><a href="/documentation.html" title="Documentation">Docs</a></li>
                         <li class="nav-sep"></li>
-                        <li><a href="/about" title="About the Dancer framework">About</a><li>
+                        <li><a href="/about.html" title="About the Dancer framework">About</a><li>
                         <li class="nav-sep"></li>
-                        <li><a href="/irc" title="Talk to us on IRC">IRC</a></li>
+                        <li><a href="/irc.html" title="Talk to us on IRC">IRC</a></li>
 		</ul>
 		<!-- END NAV LEFT -->
 		
 		<!-- START NAV RIGHT -->
 		<ul id="nav-right" class="clearme listreset">
-			<li><a href="/contribute" title="Contributing to the project">Contribute</a></li>
+			<li><a href="/contribute.html" title="Contributing to the project">Contribute</a></li>
 			<li class="nav-sep"></li>
 
 			<li><a href="/dancefloor" title="Who's using Dancer">Dancers</a></li>

--- a/views/testimonials-display.tt
+++ b/views/testimonials-display.tt
@@ -14,6 +14,6 @@
 <h3>What do <strong>you</strong> think?</h3>
 
 <p>
-We'd love to hear what you think of Dancer!  Let us know, <a href="/irc">via
+We'd love to hear what you think of Dancer!  Let us know, <a href="/irc.html">via
 IRC</a>, on the mailing list, by smoke signals - whatever you like!
 </p>


### PR DESCRIPTION
Wallflower makes it possible to generate a static website from any Plack application.

A static website has however some different requirements than a dynamic website (e.g. content-type is usually determined by the webserver using the extension), so a small rewrite was necessary.

To generate the site, install App::Wallflower (https://metacpan.org/release/App-Wallflower), possibly read the tutorial (https://metacpan.org/module/Wallflower::Tutorial), and then simply run:

```
wallflower -a bin/app.pl -d <destination>
```

You'll then have a bunch of static files that can be installed anywhere with a web server.
Add a cronjob to regenerate the files and update the site at the frequency you want, and you're done!

Note that the only page I didn't test is the dancefloor.html page, because I didn't have some of the requirements.
