### PR TITLE
Many changes to the website, mostly involving changing links D1 -> D2

### DIFF
--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -35,10 +35,9 @@ get '/dancefloor' => sub {
     };
 };
 
-# Add last tweet to template params
+# Add this year to template params
 hook before_template_render => sub {
     my $t = shift;
-    $t->{last_tweet} = latest_tweet();
     $t->{this_year} = 1900 + (localtime)[5];
 };
 
@@ -99,29 +98,6 @@ sub _get_dancefloor_sites {
             if $site->{url};
     }
     return [ sort { rand } @dancefloor_sites ];
-}
-
-# TODO: I should probably use Net::Twitter / Net::Twitter::Lite or something
-# here, but this is quick and easy and gets the job done.
-{
-    my $last_tweet;
-    my $last_tweet_checked;
-
-    sub latest_tweet {
-        return $last_tweet if $last_tweet and time - $last_tweet_checked < 300;
-
-        my $url = "http://api.twitter.com/1/statuses/user_timeline.json"
-            . "?screen_name=PerlDancer&include_rts=1&count=1";
-        my $json = LWP::Simple::get($url) or return "Unavailable";
-        my $tweets;
-        eval { $tweets = from_json($json); };
-        if (!ref $tweets || (ref $tweets eq 'HASH' && exists $tweets->{errors}))
-        {
-            return "Unavailable";
-        }
-        $last_tweet_checked = time;
-        return $last_tweet  = $tweets->[0]->{text};
-    }
 }
 
 true;

--- a/views/contribute.tt
+++ b/views/contribute.tt
@@ -21,9 +21,9 @@ If you like Dancer, tell the world about it:
 <ul>
 <li>blog about it!</li>
 <li>tweet about  it!</li>
-<li><a href="http://cpanratings.perl.org/dist/Dancer">Rate Dancer on CPAN
+<li><a href="http://cpanratings.perl.org/dist/Dancer2">Rate Dancer on CPAN
 Ratings</a></li>
-<li><a href="http://metacpan.org/release/Dancer">Click +1 on MetaCPAN</a></li>
+<li><a href="http://metacpan.org/release/Dancer2">Click +1 on MetaCPAN</a></li>
 <li><a href="https://github.com/PerlDancer/Dancer2">&quot;Watch&quot; the project on
 GitHub</a></li>
 <li>Dancer-related presentations at conferences etc (see the <a

--- a/views/documentation.tt
+++ b/views/documentation.tt
@@ -37,7 +37,7 @@ The DSL's reference API is documented in
 Dancer is PSGI-compatible, that means you can virtually deploy your app
 anywhere. We wanted to help our users as much as possible, so we've gathered as
 many details as possible in a 
-<a href="https://metacpan.org/pod/Dancer::Deployment">Deployment Guide</a>, 
+<a href="https://metacpan.org/pod/Dancer2::Manual::Deployment">Deployment Guide</a>, 
 in order to provide working configuration examples.
 </p>
 

--- a/views/includes/doc-list.tt
+++ b/views/includes/doc-list.tt
@@ -1,7 +1,7 @@
 <ul>
     <li><a href="/cheatsheet">A cheatsheet</a> (PDF or ODS) by Vladimir Lettiev
     (thecrux)</li>
-    <li><a href="http://p3rl.org/Dancer::Introduction">Dancer::Introduction</a>
+    <li><a href="http://p3rl.org/Dancer2::Manual">Dancer2::Manual</a>
     - a gentle introduction to Dancer</li>
     <li><a href="http://p3rl.org/Dancer2::Tutorial">Dancer2::Tutorial</a> - a
     walkthrough creating an example application</a></li>
@@ -11,9 +11,9 @@
     listing all the Dancer DSL keywords</li>
     <li><a href="http://p3rl.org/Dancer2::Plugins">Dancer2::Plugins</a> - a list
     of some recommended plugins to extend Dancer with useful features</li>
-    <li><a href="http://p3rl.org/Dancer::Deployment">Dancer::Deployment</a> -
+    <li><a href="http://p3rl.org/Dancer2::Manual::Deployment">Dancer2::Manual::Deployment</a> -
     how to deploy your app</li>
-    <li><a href="http://p3rl.org/Task::Dancer">Task::Dancer</a> - comprehensive
-    list of Dancer plugins, template/session/logger engines etc on the CPAN</li>
+    <li><a href="http://p3rl.org/Task::Dancer2">Task::Dancer2</a> - comprehensive
+    list of Dancer2 plugins, template/session/logger engines, etc. on the CPAN </li>
 </ul>
 

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -82,11 +82,11 @@
 
 	<div id="contain-bottom"></div>
 	
-<div class="twitter" id="jstweets">
-<a href="http://twitter.com/PerlDancer/">On Twitter</a>: <% last_tweet %> 
-</div>
-
-	<div id="copyright">Dancer Perl web framework is copyright © 2009-<% this_year %> <a href="http://sukria.net/" rel="external">Alexis Sukrieh</a> - <a href="http://github.com/PerlDancer/Dancer2/" rel="external">Fork on GitHub</a> - This website is <a href="http://github.com/PerlDancer/perldancer-website/" rel="external">free software</a>.</div>
+	<div id="copyright">Dancer Perl web framework is copyright © 2009-<% this_year %> <a href="http://sukria.net/" rel="external">Alexis Sukrieh</a> - 
+        <a href="http://twitter.com/PerlDancer/">Twitter</a> -
+        <a href="http://github.com/PerlDancer/Dancer2/" rel="external">Fork on GitHub</a> - 
+        This website is <a href="http://github.com/PerlDancer/perldancer-website/" rel="external">free software</a>.
+    </div>
 
 </div>
 

--- a/views/quickstart.tt
+++ b/views/quickstart.tt
@@ -11,7 +11,7 @@ possible.
 
 <p>
 For easy and automatic installation of Dancer, we recommend using 
-<a href="http://search.cpan.org/perldoc?cpanm">cpanminus</a>:
+<a href="https://metacpan.org/pod/distribution/Menlo/script/cpanm-menlo">cpanminus</a>:
 </p>
 
 <pre class="console">


### PR DESCRIPTION
Also, the Twitter JSON API is gone, removed the last tweet from the
bottom of the page. Instead, I put a link to Dancer's Twitter account in
the footer. Seeing "Unavailable" in the footer didn't look so hot.

Since other links use MetaCPAN instead of search.cpan.org, I changed the
cpanm link to use MetaCPAN too.

Please note: the D2 deployment link will not work until a new release of
D2 happens - Dancer::Deployment gets renamed to
Dancer2::Manual::Deployment. So this change shouldn't get deployed until
that happens :)