### PR TITLE
Change old Flash format SlideShare slides to new iframe format.

### DIFF
--- a/views/slides.tt
+++ b/views/slides.tt
@@ -10,7 +10,7 @@
 
 <p><strong>Intro to Dancer</strong></p>
 
-<p>Given at <a href="http://2012.yapcna.org/">YAPC::NAA 2012</p> by Mark Allen</p>
+<p>Given at <a href="http://2012.yapcna.org/">YAPC::NAA 2012</a> by Mark Allen</p>
 
 <script async class="speakerdeck-embed" data-id="4fd8f970a14e86002202f969" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
 
@@ -21,15 +21,13 @@
 <p>
 Given at <a href="http://pghpw.org/ppw2011/">Pittsburgh Perl Workshop 2011</a> by Stefan Hornburg (Racke)
 </p>
-<object id="__sse9656888" width="425" height="355"> <param name="movie" value="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=perlcommerce-beamer-111012060740-phpapp02&stripped_title=modern-perlcommerce&userName=linuxia" /> <param name="allowFullScreen" value="true"/> <param name="allowScriptAccess" value="always"/> <embed name="__sse9656888" src="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=perlcommerce-beamer-111012060740-phpapp02&stripped_title=modern-perlcommerce&userName=linuxia" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="425" height="355"></embed> </object>
+<iframe src="//www.slideshare.net/slideshow/embed_code/key/noTgObmZ0vqOX2" width="760" height="620" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/linuxia/modern-perlcommerce" title="Modern PerlCommerce" target="_blank">Modern PerlCommerce</a> </strong> from <strong><a target="_blank" href="//www.slideshare.net/linuxia">LinuXia</a></strong> </div>
 
 <p>
 You can also view and download this in <a href="/slides/perlcommerce-beamer.pdf">PDF format</a>
 </p>
 
 <hr />
-
-<p><strong>Dancing Tutorial</strong></p>
 
 <p><strong>
 <a href="http://www.slideshare.net/hashashin/dancing-tutorial">
@@ -39,11 +37,7 @@ Dancing Tutorial</a></strong></p>
 Given by Alberto Simoes at Braga Geek Nights, March 1st. 2011
 </p>
 
-
-<object id="__sse7100858" width="595" height="497"> <param name="movie" value="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=dancer-110301061249-phpapp01&stripped_title=dancing-tutorial&userName=hashashin" /> <param name="allowFullScreen" value="true"/> <param name="allowScriptAccess" value="always"/>
-<embed name="__sse7100858" src="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=dancer-110301061249-phpapp01&stripped_title=dancing-tutorial&userName=hashashin" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="595" height="497">
-</embed>
-</object> 
+<iframe src="//www.slideshare.net/slideshow/embed_code/key/jGGW8gQdW5Wbp6" width="760" height="620" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/hashashin/dancing-tutorial" title="Dancing Tutorial" target="_blank">Dancing Tutorial</a> </strong> from <strong><a target="_blank" href="//www.slideshare.net/hashashin">Alberto Simões</a></strong> </div>
 
 <p>
 You can also view and download this in 
@@ -58,7 +52,7 @@ Perl Dancer for Python programmers</a>
 
 <p>(Given by Sawyer at PyWebIL, Oct 4th 2010 in Israel)</p>
 
-<object id="__sse5369570" width="595" height="497"> <param name="movie" value="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=dancer-101006033841-phpapp01&stripped_title=perl-dancer-for-python-programmers&userName=xSawyer" /> <param name="allowFullScreen" value="true"/> <param name="allowScriptAccess" value="always"/> <embed name="__sse5369570" src="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=dancer-101006033841-phpapp01&stripped_title=perl-dancer-for-python-programmers&userName=xSawyer" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="595" height="497"></embed> </object>
+<iframe src="//www.slideshare.net/slideshow/embed_code/key/ztRzGa6Djcksus" width="760" height="620" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/xSawyer/perl-dancer-for-python-programmers" title="Perl Dancer for Python programmers" target="_blank">Perl Dancer for Python programmers</a> </strong> de <strong><a target="_blank" href="//www.slideshare.net/xSawyer">xSawyer</a></strong> </div>
 
 <p>
 You can also view and download this in 
@@ -77,7 +71,7 @@ Perl Dancer, FPW 2010</a>
 Given by Alexis Sukrieh at French Perl Workshop, 11th June 2010, Calais
 </p>
 
-<object id="__sse4482016" width="595" height="497"> <param name="movie" value="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=fpw2010-perldancer-100612140837-phpapp01&stripped_title=perl-dancer-fpw-2010-4482016&userName=asukrieh" /> <param name="allowFullScreen" value="true"/> <param name="allowScriptAccess" value="always"/> <embed name="__sse4482016" src="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=fpw2010-perldancer-100612140837-phpapp01&stripped_title=perl-dancer-fpw-2010-4482016&userName=asukrieh" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="595" height="497"></embed> </object>
+<iframe src="//www.slideshare.net/slideshow/embed_code/key/arSQmk6CIX0sTX" width="760" height="620" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/asukrieh/perl-dancer-fpw-2010-4482016" title="Perl Dancer, FPW 2010" target="_blank">Perl Dancer, FPW 2010</a> </strong> from <strong><a target="_blank" href="//www.slideshare.net/asukrieh">Alexis Sukrieh</a></strong> </div>
 
 <p>You can also view and download this in
 <a href="/slides/perl-dancer-fpw-2010.odp">OpenOffice ODP format</a>.</p>
@@ -93,8 +87,7 @@ Writing webapps with Perl Dancer</a>
 Given by Alexis Sukrieh at OSDCfr 2009
 </p>
 
-
-<object id="__sse2116491" width="595" height="497"><param name="movie" value="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=osdcfr2009-dancer-091003101341-phpapp02&stripped_title=writing-webapps-with-perl-dancer&userName=asukrieh" /> <param name="allowFullScreen" value="true"/> <param name="allowScriptAccess" value="always"/> <embed name="__sse2116491" src="http://static.slidesharecdn.com/swf/ssplayer2.swf?doc=osdcfr2009-dancer-091003101341-phpapp02&stripped_title=writing-webapps-with-perl-dancer&userName=asukrieh" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="595" height="497"></embed> </object> 
+<iframe src="//www.slideshare.net/slideshow/embed_code/key/xL4K7p8MUfZc1H" width="760" height="620" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/asukrieh/writing-webapps-with-perl-dancer" title="Writing webapps with Perl Dancer" target="_blank">Writing webapps with Perl Dancer</a> </strong> from <strong><a target="_blank" href="//www.slideshare.net/asukrieh">Alexis Sukrieh</a></strong> </div>
 
 <p>
 You can also view and download this in


### PR DESCRIPTION
Flash Formats No Longer Supported on SlideShare
https://www.linkedin.com/help/linkedin/answer/56328?lang=en

So use the new way. Also fix a couple of markup errors.