### PR TITLE
Remove link to add new CPAN ratings

### DIFF
--- a/views/contribute.tt
+++ b/views/contribute.tt
@@ -21,8 +21,6 @@ If you like Dancer, tell the world about it:
 <ul>
 <li>blog about it!</li>
 <li>tweet about  it!</li>
-<li><a href="http://cpanratings.perl.org/dist/Dancer2">Rate Dancer on CPAN
-Ratings</a></li>
 <li><a href="http://metacpan.org/release/Dancer2">Click +1 on MetaCPAN</a></li>
 <li><a href="https://github.com/PerlDancer/Dancer2">&quot;Watch&quot; the project on
 GitHub</a></li>


### PR DESCRIPTION
CPAN Ratings has been read-only since 2018, and cannot accept new
ratings, so asking users to add ratings there seems silly. See
https://log.perl.org/2018/06/cpan-ratings-read-only.html for more
details.

Thanks to dwwalker for reporting.