### PR TITLE
Fix broken download button on landing page

### DIFF
--- a/lib/PerlDancer.pm
+++ b/lib/PerlDancer.pm
@@ -63,19 +63,13 @@ hook before_template_render => sub {
         }
 
         my $json = LWP::Simple::get(
-            'http://api.metacpan.org/v0/release/Dancer2'
+            'https://fastapi.metacpan.org/v1/release/Dancer2'
         ) or return $latest_version;
 
         my $response = from_json($json) or return $latest_version;
-        my ($short_ver) = $response->{version} =~ /^(\d+\.\d{3})/;
-        my $result =  {
-            version       => $response->{version},
-            short_version => $short_ver,
-            download_url  => $response->{download_url},
-        };
-        $latest_version = $result;
+        $latest_version = $response->{download_url};
         $last_check = time;
-        return $result;
+        return $latest_version;
     }
 }
 

--- a/views/index.tt
+++ b/views/index.tt
@@ -214,8 +214,8 @@ ajax '/getloadavg' => sub {
 
 
 	<ul class="clearme listreset dbc">
-		<li><a href="<% latest.download_url %>" id="contain-download">
-                <% latest.short_version %>&nbsp;</a></li>
+		<li><a href="<% latest %>" id="contain-download">
+                &nbsp;</a></li>
 	<li>You can also follow Dancer on <a
         href="https://github.com/PerlDancer/Dancer2">GitHub</a> and on <a href="https://twitter.com/PerlDancer">Twitter</a></li>
 	</ul>


### PR DESCRIPTION
MetaCPAN API v0 has been deprecated and shut down, so we could never fill in the download information for the button. The response is slightly different in v1 than v0, so adjusted accordingly - there's no reason to keep short_version and version, so I removed short_version.

The version for Dancer2 doesn't fit as cleanly as the version for Dancer, so I removed it from the button display entirely.