### PR TITLE
Replace Google Analytics with Plausible

### DIFF
--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -26,6 +26,7 @@
     !window.jQuery && document.write('<script type="text/javascript" src="/javascripts/jquery.js"><\/script>')
 	/* ]]> */</script>
 
+	<script defer data-domain="perldancer.org" src="https://plausible.io/js/script.js"></script>
 
 </head>
 <body onload="prettyPrint()">
@@ -98,18 +99,5 @@
 
 <a href="https://github.com/PerlDancer/Dancer2/fork"><img src="/images/forkme_right_darkblue_121621.svg" style="position:absolute;top:0;right:0;" alt="Fork me on GitHub"></a>
 
-<script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-25174467-1']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
-</script>
 </body>
 </html>


### PR DESCRIPTION
Google retired Universal Analytics at the end of June, so we weren't collecting stats anyhow. Plausible is less invasive, more privacy friendly, based in the EU, and plays nicely with CA and EU regulations.