### PR TITLE
Create a framework for Core Team bios

### DIFF
--- a/views/core-team.tt
+++ b/views/core-team.tt
@@ -1,0 +1,37 @@
+<a name="top"></a>
+<h3>Meet the Core Team</h3>
+
+<p>
+These Dancers know how to bust a move or two! Learn about the team that
+brings you Dancer:</p>
+
+<ul>
+<li>Alberto Simões (ambs)</li>
+<li>Alexis Sukrieh (sukria)</li>
+<li>D Ruth Holloway (GeekRuthie)</li>
+<li>Damien Krotkine (dams)</li>
+<li>David Precious (bigpresh)</li>
+<li>Franck Cuny (franckc)</li>
+<li>Jason A. Crome (CromeDome)</li>
+<li>Mickey Nasriachi</li>
+<li>Peter Mottram (SysPete)</li>
+<li>Russell Jenkins (veryrusty)</li>
+<li>Sawyer X</li>
+<li>Stefan Hornburg (racke)</li>
+<li>Yanick Champoux</li>
+</ul>
+
+<a name="ambs"></a>
+<a name="sukria"></a>
+<a name="geetkruthie"></a>
+<a name="dams"></a>
+<a name="bigpresh"></a>
+<a name="franckc"></a>
+<a name="cromedome"></a>
+<a name="mickey"></a>
+<a name="syspete"></a>
+<a name="veryrusty"></a>
+<a name="xsawyerx"></a>
+<a name="racke"></a>
+<a name="yanick"></a>
+

--- a/views/documentation.tt
+++ b/views/documentation.tt
@@ -46,3 +46,8 @@ Even though special care is given to documentation, there might be some
 errors, so feel free to <a href="/about">contact the development team</a> if
 you find any.
 </p>
+
+<h3>Presentations</h3>
+<p>
+<a href="/slides" title="Presentation slides">See presentations from Dancer talks around the world!</a>
+</p>

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -60,7 +60,7 @@
 			<li><a href="/dancefloor" title="Who's using Dancer">Dancers</a></li>
 			<li class="nav-sep"></li>
 
-                        <li><a href="/slides" title="Presentation slides">Slides</a></li>
+                        <li><a href="/core-team" title="Meet the Core Team">Core Team</a></li>
 		</ul>
 		<!-- END NAV RIGHT -->
 			


### PR DESCRIPTION
I added a link to the Slides page to the documentation page, and removed it from the menu to make room for a Core Team link. From there, created a basic page that lists each of us. In subsequent commits, we can add mini-bios for each of us.

This is to address #70.